### PR TITLE
Strip rasa as a dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 vcap-local.json
 .venv
 __pycache__
-.rasa
 .vscode
 diagnostics.txt
 out_path.txt

--- a/conda_list.txt
+++ b/conda_list.txt
@@ -150,8 +150,6 @@ pytz-deprecation-shim     0.1.0.post0              pypi_0    pypi
 pyyaml                    6.0                      pypi_0    pypi
 questionary               1.10.0                   pypi_0    pypi
 randomname                0.1.5                    pypi_0    pypi
-rasa                      3.3.1                    pypi_0    pypi
-rasa-sdk                  3.3.0                    pypi_0    pypi
 readline                  8.2                  h5eee18b_0  
 redis                     4.3.5                    pypi_0    pypi
 regex                     2022.9.13                pypi_0    pypi

--- a/contingent_plan_executor/app.py
+++ b/contingent_plan_executor/app.py
@@ -4,7 +4,7 @@ from hovor.core import initialize_session
 from hovor.configuration.direct_json_configuration_provider import DirectJsonConfigurationProvider
 from hovor.execution_monitor import EM
 from environment import initialize_remote_environment
-from local_run_utils import run_rasa_model_server
+from local_run_utils import run_model_server
 from flask import request, jsonify
 import json, jsonpickle
 import traceback
@@ -84,7 +84,7 @@ def new_conversation():
 
         print("Plan fetched.")
 
-        run_rasa_model_server(out_path)
+        run_model_server(out_path)
 
         print("Creating a new trace.")
         temp_session = initialize_session(plan_config)
@@ -204,7 +204,7 @@ def new_message():
 
         print("Plan fetched.")
 
-        run_rasa_model_server(out_path)
+        run_model_server(out_path)
 
         # Only proceed if the trace exists
         if not check_db(trace_id):
@@ -313,7 +313,7 @@ def load_conversation():
 
     print("Plan fetched.")
 
-    run_rasa_model_server(out_path)
+    run_model_server(out_path)
 
     # Only proceed if the trace exists
     if not check_db(trace_id):

--- a/contingent_plan_executor/hovor/configuration/json_configuration_provider.py
+++ b/contingent_plan_executor/hovor/configuration/json_configuration_provider.py
@@ -8,7 +8,7 @@ from hovor.outcome_determiners.context_dependent_outcome_determiner import Conte
 from hovor.outcome_determiners.default_system_outcome_determiner import DefaultSystemOutcomeDeterminer
 from hovor.outcome_determiners.outcome_determination_info import OutcomeDeterminationInfo
 from hovor.outcome_determiners.random_outcome_determiner import RandomOutcomeDeterminer
-from hovor.outcome_determiners.rasa_outcome_determiner import RasaOutcomeDeterminer
+from hovor.outcome_determiners.rasa_outcome_determiner import NLUOutcomeDeterminer
 from hovor.outcome_determiners.web_call_outcome_determiner import WebCallOutcomeDeterminer
 from hovor.planning import controller
 from hovor.planning.controller.edge import ControllerEdge
@@ -228,7 +228,7 @@ class JsonConfigurationProvider(ConfigurationProviderBase):
             return DefaultSystemOutcomeDeterminer()
 
         if outcome_determiner_name == "disambiguation_outcome_determiner":
-            return RasaOutcomeDeterminer(action_name, outcome_config["outcomes"], self._configuration_data["context_variables"], self._configuration_data["intents"])
+            return NLUOutcomeDeterminer(action_name, outcome_config["outcomes"], self._configuration_data["context_variables"], self._configuration_data["intents"])
 
         if outcome_determiner_name == "web_call_outcome_determiner":
             return WebCallOutcomeDeterminer()

--- a/contingent_plan_executor/hovor/configuration/json_configuration_provider.py
+++ b/contingent_plan_executor/hovor/configuration/json_configuration_provider.py
@@ -8,7 +8,7 @@ from hovor.outcome_determiners.context_dependent_outcome_determiner import Conte
 from hovor.outcome_determiners.default_system_outcome_determiner import DefaultSystemOutcomeDeterminer
 from hovor.outcome_determiners.outcome_determination_info import OutcomeDeterminationInfo
 from hovor.outcome_determiners.random_outcome_determiner import RandomOutcomeDeterminer
-from hovor.outcome_determiners.rasa_outcome_determiner import NLUOutcomeDeterminer
+from hovor.outcome_determiners.nlu_outcome_determiner import NLUOutcomeDeterminer
 from hovor.outcome_determiners.web_call_outcome_determiner import WebCallOutcomeDeterminer
 from hovor.planning import controller
 from hovor.planning.controller.edge import ControllerEdge

--- a/contingent_plan_executor/hovor/hovor_beam_search/init_stubs.py
+++ b/contingent_plan_executor/hovor/hovor_beam_search/init_stubs.py
@@ -1,4 +1,4 @@
-from hovor.outcome_determiners.rasa_outcome_determiner import RasaOutcomeDeterminer
+from hovor.outcome_determiners.rasa_outcome_determiner import NLUOutcomeDeterminer
 from hovor.hovor_beam_search.semantic_similarity import (
     softmax_confidences,
     semantic_similarity,
@@ -123,7 +123,7 @@ class HovorRollout(RolloutBase):
         self._progress.json["action_result"]["fields"]["input"] = utterance["USER"]
         ranked_groups = self.call_outcome_determiner(
             action,
-            RasaOutcomeDeterminer(
+            NLUOutcomeDeterminer(
                 action,
                 data["actions"][action]["effect"]["outcomes"],
                 data["context_variables"],

--- a/contingent_plan_executor/hovor/outcome_determiners/__init__.py
+++ b/contingent_plan_executor/hovor/outcome_determiners/__init__.py
@@ -1,8 +1,6 @@
 import nltk
 import spacy
 
-ws_action_outcome_determiner_config = []
-all_entities = {}
 nltk.download('wordnet')
 nltk.download('omw-1.4')
 

--- a/contingent_plan_executor/hovor/outcome_determiners/nlu_outcome_determiner.py
+++ b/contingent_plan_executor/hovor/outcome_determiners/nlu_outcome_determiner.py
@@ -46,10 +46,14 @@ class NLUOutcomeDeterminer(OutcomeDeterminerBase):
         # cache the extracted entities so we don't have to extract anything multiple times
         self.extracted_entities = {}
 
-
     @staticmethod
     def parse_synset_name(synset):
         return synset.name().split(".")[0]
+
+    def find_spacy_entity(self, method: str):
+        if method in self.spacy_entities:
+            if self.spacy_entities[method]:
+                return self.spacy_entities[method].pop()
 
     def find_x_entity(self, entity: str):
         """
@@ -57,7 +61,7 @@ class NLUOutcomeDeterminer(OutcomeDeterminerBase):
 
         Return the entity if it exists.
 
-        Create one of these for every extraction type (i.e. spacy) used 
+        Create one of these for every extraction type (i.e. spacy) used
 
         Args:
             entity (str): The entity to retrieve
@@ -67,11 +71,7 @@ class NLUOutcomeDeterminer(OutcomeDeterminerBase):
         """
         if entity in self.x_entities:
             return self.x_entities[entity]
-
-    def find_spacy_entity(self, method: str):
-        if method in self.spacy_entities:
-            if self.spacy_entities[method]:
-                return self.spacy_entities[method].pop()
+        raise NotImplementedError("Implement this function.")
 
     def initialize_extracted_entities(self, entities: Dict):
         """
@@ -79,10 +79,10 @@ class NLUOutcomeDeterminer(OutcomeDeterminerBase):
 
         Initialize the entities into their respective categories.
         You want to do this so you can extract entities according to their extraction
-        specifications, as well as set "orderings" for extraction types. for example, 
+        specifications, as well as set "orderings" for extraction types. for example,
         for a "number" entity (with allowed "maybe" knowledge) set to be extracted with
-        rasa, it was extracted with rasa, and if that failed an extraction was 
-        attempted with spacy's "CARDINAL" with the "maybe" knowledge setting. 
+        rasa, it was extracted with rasa, and if that failed an extraction was
+        attempted with spacy's "CARDINAL" with the "maybe" knowledge setting.
 
         Args:
             entities (Dict): The raw entities extracted.
@@ -97,81 +97,88 @@ class NLUOutcomeDeterminer(OutcomeDeterminerBase):
                     self.spacy_entities[extracted["entity"]] = [extracted]
             else:
                 self.x_entities[extracted["entity"]] = extracted
+                raise NotImplementedError("Implement this.")
 
     # TODO: replace with general "execute with ordering" function
-    # def try_rasa_then_spacy(self, entity: str):
-    #     extracted = self.find_rasa_entity(entity)
-    #     if not extracted:
-    #         if self.spacy_entities.values():
-    #             extracted = []
-    #             extracted.extend(
-    #                 val
-    #                 for method_vals in self.spacy_entities.values()
-    #                 for val in method_vals
-    #             )
-    #             extracted = random.choice(extracted)
-    #             certainty = "maybe-found"
-    #         else:
-    #             return None, None
-    #     else:
-    #         certainty = "found"
-    #     return extracted, certainty
+    def determine_extraction_ordering(self, entity: str):
+        """Determines the extraction ordering of the entity based on its
+        extraction settings.
 
-    # def try_spacy_then_rasa(self, entity: str):
-    #     extracted = self.find_spacy_entity(
-    #         self.context_variables[entity]["config"]["extraction"]["config_method"].upper()
-    #     )
-    #     if not extracted:
-    #         # if we can't parse with spacy, try with Rasa (may also return None)
-    #         extracted = self.find_rasa_entity(entity)
-    #         if not extracted:
-    #             return None, None
-    #         certainty = "maybe-found"
-    #     else:
-    #         certainty = "found"
-    #     return extracted, certainty
+        For reference, these were the orderings previously used when Rasa
+        was used for NLU (feel free to use these or make your own).
+        - if specified to use "spacy":
+            - try extracting with spacy, then rasa.
+        - if there is no specification (i.e. rasa):
+            - try extracting with rasa, then spacy.
+        - if it is a regex:
+            - try extracting with rasa first and checking the pattern.
+              otherwise, try with spacy and checking the pattern against
+              any extracted CARDINAL values. (since this extraction is
+              different, it has its own function, so specify this with "regex").
 
+        Args:
+            entity (str): The name of the entity.
+
+        Returns (List[str]): List of strings that represents the ordering.
+        """
+        raise NotImplementedError("Implement this function.")
 
     # TODO: turn into stub
     def extract_regex(self, entity):
         """For regexes, it doesn't matter whether what extracted it
         ("regex" is its own category). Just try with all relevant extraction methods--
-        results will always be "found" or "didnt-find". Also, for spacy, we will only
-        check for "CARDINAL" extractions.
+        results will always be "found" or "didnt-find".
         """
         extracted = None
 
         pattern = self.context_variables[entity]["config"]["extraction"]["pattern"]
-        raw_extracted = self.find_x_entity(entity)
-        if raw_extracted:
-            match = re.fullmatch(pattern, raw_extracted["value"])
-            if match:
-                extracted = raw_extracted
-        if not extracted:
-            if self.spacy_entities:
-                if "CARDINAL" in self.spacy_entities:
-                    # iterate through all CARDINAL entities and see if any match
-                    for ext_ent in self.spacy_entities["CARDINAL"]:
-                        match = re.fullmatch(pattern, ext_ent["value"])
-                        if match:
-                            extracted = ext_ent
-                            break
+        if self.spacy_entities:
+            if "CARDINAL" in self.spacy_entities:
+                # iterate through all CARDINAL entities and see if any match
+                for ext_ent in self.spacy_entities["CARDINAL"]:
+                    match = re.fullmatch(pattern, ext_ent["value"])
+                    if match:
+                        extracted = ext_ent
+                        break
             else:
-                return None, None
-        return extracted, "found"
+                return None
+        else:
+            raise NotImplementedError(
+                "Search other extraction types for numbers we \
+can check against the regex (optional)."
+            )
+        return extracted
 
     def extract_entity(self, entity: str):
-        # for "complex" json configurations
-        if self.context_variables[entity]["type"] == "json":
-            # can be either "method" (like spacy) or "pattern" (like a regex)
-            method = self.context_variables[entity]["config"]["extraction"]["method"]
-            if method == "spacy":
-                extracted, certainty = self.try_spacy_then_rasa(entity)
-            elif method == "regex":
-                extracted, certainty = self.extract_regex(entity)
-        # rasa
-        else:
-            extracted, certainty = self.try_rasa_then_spacy(entity)
+        """Extract an entity according to the extraction ordering.
+
+        Args:
+            entity (str): The name of the entity.
+
+        Returns:
+            Optional[Dict]: Contains the extraction information if extracted;
+                otherwise None.
+        """
+        ordering = self.determine_extraction_ordering(entity)
+        for i in range(len(ordering)):
+            # attempt to extract the entity
+            if ordering[i] == "regex":
+                extracted = self.extract_regex(entity)
+            elif ordering[i] == "spacy":
+                extracted = self.find_spacy_entity(
+                    self.context_variables[entity]["config"]["extraction"][
+                        "config_method"
+                    ].upper()
+                )
+            else:
+                raise NotImplementedError("Implement this.")
+            if extracted:
+                # certainty won't be "known" if we didn't extract with our first pick
+                # ignore this with regexes though (don't really care where we get it 
+                # from as long as we get a match)
+                certainty = ("known" if i == 0 else "maybe-known") \
+                             if ordering != "regex" else "known"
+                break
         if extracted:
             return {
                 "extracted": extracted,
@@ -180,8 +187,16 @@ class NLUOutcomeDeterminer(OutcomeDeterminerBase):
             }
 
     def extract_entities(self, intent):
+        """Attempts to extract all entities from an intent.
+
+        Args:
+            intent (Intent): The intent to extract from.
+
+        Returns:
+            Dict: The entities extracted.
+        """
         entities = {}
-        # get entities from frozenset
+        # get entity requirements
         for entity in {f[0] for f in intent.entity_reqs}:
             if entity in self.extracted_entities:
                 entities[entity] = self.extracted_entities[entity]
@@ -201,25 +216,49 @@ class NLUOutcomeDeterminer(OutcomeDeterminerBase):
         return entities
 
     def filter_intents(self, r, outcome_groups):
+        """Filters the intents based on the entities extracted.
+        We do this because we don't want to waste computation validating an intent 
+        if any of the entities it needs were not extracted in any capacity and it 
+        will ultimately be thrown out.
+
+        Note that we only look at the raw extractions in this step. 
+
+        Args:
+            r (Dict): The JSON response from the NLU call
+            outcome_groups (List): The outcome groups for this action (these determine
+                which intents are in our scope).
+
+        Returns:
+            (List[Intent]): The list of filtered Intents to attempt extractions from. 
+        """
         # make outcome groups accessible by name
-        outcome_groups = {out.name : out for out in outcome_groups}
-        intents_detected = {ranking["name"]: ranking["confidence"] for ranking in r["intent_ranking"]}
+        outcome_groups = {out.name: out for out in outcome_groups}
+        intents_detected = {
+            ranking["name"]: ranking["confidence"] for ranking in r["intent_ranking"]
+        }
         intents = []
         for out, out_cfg in self.full_outcomes.items():
-            # check to make sure this intent was at least DETECTED by rasa
+            # check to make sure this intent was at least DETECTED
             if out_cfg["intent"] in intents_detected:
                 if self.intents[out_cfg["intent"]]["entities"]:
-                    # we only want to consider assignments that are variables of the intent, as outcomes often
-                    # have other updates for existing entities.
-                    entity_reqs = {e[1:]:cert for e, cert in out_cfg["assignments"].items() if e in self.intents[out_cfg["intent"]]["entities"]}
+                    # we only want to consider assignments that are variables of the 
+                    # intent, as outcomes often have other updates for existing entities.
+                    entity_reqs = {
+                        e[1:]: cert
+                        for e, cert in out_cfg["assignments"].items()
+                        if e in self.intents[out_cfg["intent"]]["entities"]
+                    }
 
                     intents.append(
                         Intent(
-                            out_cfg["intent_cfg"] if "intent_cfg" in out_cfg else out_cfg["intent"],
-                            # use the assignments key so we get the required certainty for each entity
+                            out_cfg["intent_cfg"]
+                            if "intent_cfg" in out_cfg
+                            else out_cfg["intent"],
+                            # use the assignments key so we get the required certainty
+                            # for each entity
                             frozenset(entity_reqs.items()),
                             outcome_groups[out],
-                            intents_detected[out_cfg["intent"]]
+                            intents_detected[out_cfg["intent"]],
                         )
                     )
                 else:
@@ -228,29 +267,38 @@ class NLUOutcomeDeterminer(OutcomeDeterminerBase):
                             out_cfg["intent"],
                             None,
                             outcome_groups[out],
-                            intents_detected[out_cfg["intent"]]
+                            intents_detected[out_cfg["intent"]],
                         )
                     )
             elif out_cfg["intent"] == "fallback":
-                intents.append(
-                    Intent(
-                        "fallback",
-                        None,
-                        outcome_groups[out],
-                        0
-                    )
-                )
+                intents.append(Intent("fallback", None, outcome_groups[out], 0))
         intents.sort()
         return intents
 
     def extract_intents(self, intents):
+        """Extracts the intents by iterating through the filtered intents and selecting
+        the first one where all entities are extracted correctly.
+
+        Args:
+            intents (List[Intents]): The filtered intents.
+
+        Returns:
+            intents (List[Intents]): The intent ranking, adjusted by the updated 
+                confidences.
+        """
         entities = {}
         extracted_intent = None
         for intent in intents:
             # if this intent expects entities, make sure we extract them
             if intent.entity_reqs != None:
                 entities = self.extract_entities(intent)
-                if intent.entity_reqs == frozenset({entity: entities[entity]["certainty"] for entity in entities if entities[entity]["certainty"] != "didnt-find"}.items()):
+                if intent.entity_reqs == frozenset(
+                    {
+                        entity: entities[entity]["certainty"]
+                        for entity in entities
+                        if entities[entity]["certainty"] != "didnt-find"
+                    }.items()
+                ):
                     extracted_intent = intent
                     break
                 # need to reassign to None because we only get here if for some reason we weren't
@@ -269,21 +317,35 @@ class NLUOutcomeDeterminer(OutcomeDeterminerBase):
             # cuisine is "found" and the sister intent share_cuisine where cuisine is "maybe-found" will
             # have the same confidence, but we only want the right one to be chosen.
             for intent in intents:
-                if intent.name == extracted_intent.name and intent.entity_reqs != extracted_intent.entity_reqs:
+                if (
+                    intent.name == extracted_intent.name
+                    and intent.entity_reqs != extracted_intent.entity_reqs
+                ):
                     intent.confidence = 0
 
         for intent in intents:
             if intent.name == "fallback":
-                intent.confidence = 1 - max(intents, key=attrgetter("confidence")).confidence
+                intent.confidence = (
+                    1 - max(intents, key=attrgetter("confidence")).confidence
+                )
                 break
 
         # rearrange intent ranking
         intents.sort()
 
-        return intents[0], intents
-
+        return intents
 
     def get_raw_rankings(self, input, outcome_groups):
+        """Gets the raw intent rankings given the user input.
+
+        Args:
+            input (str): The user utterance.
+            outcome_groups (List): The outcome groups for this action (these determine
+                which intents are in our scope).
+
+        Returns:
+            intents (List[Intents]): The intent ranking.
+        """
         r = json.loads(
             requests.post(
                 "http://localhost:5006/model/parse", json={"text": input}
@@ -294,18 +356,33 @@ class NLUOutcomeDeterminer(OutcomeDeterminerBase):
         return self.extract_intents(intents)
 
     def rank_groups(self, outcome_groups, progress):
-        chosen_intent, intents = self.get_raw_rankings(
+        """Ranks the outcome groups and updates the progress.
+
+        Args:
+            outcome_groups (List): The outcome groups for this action (these determine
+                which intents are in our scope).
+            progress (OutcomeDeterminationProgress): Keeps track of the context.
+
+        Raises:
+            ValueError: Raised if you tried to assign an entity to a value we don't have yet
+
+        Returns:
+            List[tuple]: The ranked outcome groups.
+            OutcomeDeterminationProgress: The updated progress.
+        """
+        intents = self.get_raw_rankings(
             progress.json["action_result"]["fields"]["input"], outcome_groups
         )
-        ranked_groups = [
-            (intent.outcome, intent.confidence) for intent in intents
-        ]
+        chosen_intent = intents[0]
+        ranked_groups = [(intent.outcome, intent.confidence) for intent in intents]
         # entities required by the extracted intent
         if chosen_intent.entity_reqs:
             ci_ent_reqs = [er[0] for er in chosen_intent.entity_reqs]
         # note we shouldn't only add samples for extracted entities; some outcomes don't
         # extract entities themselves but update the values of existing entities
-        for update_var, update_config in progress.get_description(chosen_intent.outcome.name)["updates"].items():
+        for update_var, update_config in progress.get_description(
+            chosen_intent.outcome.name
+        )["updates"].items():
             if "value" in update_config:
                 if progress.get_entity_type(update_var) in ["json", "enum"]:
                     value = update_config["value"]
@@ -324,16 +401,44 @@ class NLUOutcomeDeterminer(OutcomeDeterminerBase):
                                         value = self.extracted_entities[value]["sample"]
                                     # otherwise, we tried to assign an entity to a value we don't have yet
                                     else:
-                                        raise ValueError("Tried to assign an entity to \
-                                                        an unknown variable value.")
+                                        raise ValueError(
+                                            "Tried to assign an entity to \
+                                                        an unknown variable value."
+                                        )
                     progress.add_detected_entity(update_var, value)
-        # DEBUG("\t top random ranking for group '%s'" % (chosen_intent.name))
+        DEBUG("\t top random ranking for group '%s'" % (chosen_intent.name))
         return ranked_groups, progress
 
-    def _make_entity_type_sample(self, entity, entity_type, entity_config, extracted_info):
+    def _make_entity_type_sample(
+        self, entity, entity_type, entity_config, extracted_info
+    ):
+        """Extracts the actual value of the entity.
+        Fixes spelling errors if they exist and attempts to map it to similar words
+        if it is not an exact match to the entity configuration.
+
+        Args:
+            entity (str): Name of the entity.
+            entity_type (str): Type of the entity.
+            entity_config (Dict): The possible values for the entity.
+            extracted_info (Dict): The raw extraction data for the entity.
+
+        Raises:
+            NotImplementedError: Raised if we tried to sample from an unknown entity
+            type.
+
+        Returns:
+            (Dict): The extraction info for the entity.
+        """
         entity_value = extracted_info["value"]
         # entity is extracted with spacy and has options specified
-        spacy_w_opts = (entity_config["extraction"]["method"] == "spacy" and "options" in entity_config) if entity_type == "json" else False
+        spacy_w_opts = (
+            (
+                entity_config["extraction"]["method"] == "spacy"
+                and "options" in entity_config
+            )
+            if entity_type == "json"
+            else False
+        )
         if spacy_w_opts:
             entity_config = entity_config["options"]
         if spacy_w_opts or entity_type == "enum":
@@ -348,7 +453,9 @@ class NLUOutcomeDeterminer(OutcomeDeterminerBase):
                     if self.context_variables[entity]["known"]["type"] == "fflag":
                         extracted_info["certainty"] = "maybe-found"
                         # first try correcting spelling
-                        spell_corrected_e_val = TextBlob(entity_value).correct().raw.lower()
+                        spell_corrected_e_val = (
+                            TextBlob(entity_value).correct().raw.lower()
+                        )
                         if spell_corrected_e_val != entity_value:
                             entity_value = spell_corrected_e_val
                             if entity_value in entity_config:
@@ -372,22 +479,30 @@ class NLUOutcomeDeterminer(OutcomeDeterminerBase):
                                         extracted_info["sample"] = entity_config[d]
                                         return extracted_info
                             for hyp in syn.hypernyms():
-                                hyp = NLUOutcomeDeterminer.parse_synset_name(hyp).lower()
+                                hyp = NLUOutcomeDeterminer.parse_synset_name(
+                                    hyp
+                                ).lower()
                                 if hyp in entity_config:
                                     extracted_info["sample"] = entity_config[hyp]
                                     return extracted_info
                             for hyp in syn.hyponyms():
-                                hyp = NLUOutcomeDeterminer.parse_synset_name(hyp).lower()
+                                hyp = NLUOutcomeDeterminer.parse_synset_name(
+                                    hyp
+                                ).lower()
                                 if hyp in entity_config:
                                     extracted_info["sample"] = entity_config[hyp]
                                     return extracted_info
                             for hol in syn.member_holonyms():
-                                hol = NLUOutcomeDeterminer.parse_synset_name(hol).lower()
+                                hol = NLUOutcomeDeterminer.parse_synset_name(
+                                    hol
+                                ).lower()
                                 if hol in entity_config:
                                     extracted_info["sample"] = entity_config[hol]
                                     return extracted_info
                             for hol in syn.root_hypernyms():
-                                hol = NLUOutcomeDeterminer.parse_synset_name(hol).lower()
+                                hol = NLUOutcomeDeterminer.parse_synset_name(
+                                    hol
+                                ).lower()
                                 if hol in entity_config:
                                     extracted_info["sample"] = entity_config[hol]
                                     return extracted_info

--- a/contingent_plan_executor/local_run_utils.py
+++ b/contingent_plan_executor/local_run_utils.py
@@ -15,28 +15,29 @@ def create_validate_json_config_prov(output_files_path):
     configuration_provider.check_all_action_builders()
     return configuration_provider
 
-def run_rasa_model_server(output_files_path):
+def run_model_server(output_files_path):
     # check if the model is already running before proceeding
     try:
         requests.post("http://localhost:5006/model/parse", json={"text": ""})
     except requests.exceptions.ConnectionError:
-        subprocess.Popen(f"rasa run --enable-api -m {output_files_path}/nlu_model.tar.gz -p 5006", shell=True)
-        while True:
-            try:
-                requests.post("http://localhost:5006/model/parse", json={"text": ""})
-            except requests.exceptions.ConnectionError:
-                sleep(0.1)
-            else:
-                break
+        raise NotImplementedError("Replace with new NLU model.")
+        # subprocess.Popen(f"rasa run --enable-api -m {output_files_path}/nlu_model.tar.gz -p 5006", shell=True)
+        # while True:
+        #     try:
+        #         requests.post("http://localhost:5006/model/parse", json={"text": ""})
+        #     except requests.exceptions.ConnectionError:
+        #         sleep(0.1)
+        #     else:
+        #         break
 
 def initialize_local_run(output_files_path, get_cfg: bool = True):
     initialize_local_environment()
-    run_rasa_model_server(output_files_path)
+    run_model_server(output_files_path)
     if get_cfg:
         return create_validate_json_config_prov(output_files_path)
     
 def initialize_local_run_simulated(output_files_path, get_cfg: bool = True):
     initialize_local_environment_simulated()
-    run_rasa_model_server(output_files_path)
+    run_model_server(output_files_path)
     if get_cfg:
         return create_validate_json_config_prov(output_files_path)

--- a/contingent_plan_executor/local_simulate_evaluate_utils.py
+++ b/contingent_plan_executor/local_simulate_evaluate_utils.py
@@ -25,7 +25,7 @@ def simulate_local_conversations(output_files_path, log_output_dir, n_convos, sl
 
     # launch the server once at the start
     print('Launching the server...')
-    run_rasa_model_server(output_files_path)
+    run_model_server(output_files_path)
     print('Server should be launched! Now simulating conversations...')
 
     if os.path.exists(log_output_dir) and overwrite_output_dir:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ json2html
 jsonpickle
 nltk
 spacy
-tensorflow==2.12.*
 textblob
 graphviz
 docker

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ jsonpickle
 nltk
 spacy
 tensorflow==2.12.*
-rasa==3.6.1a1
 textblob
 graphviz
 docker

--- a/requirements_sim.txt
+++ b/requirements_sim.txt
@@ -7,7 +7,6 @@ jsonpickle
 nltk
 spacy
 tensorflow>=2.11.0
-rasa==3.5.6
 textblob
 graphviz
 docker


### PR DESCRIPTION
Closes #15 .

- When building and running the docker (see the README on the front page), you will get an exception thrown about a missing NLUOutcomeDeterminer.
- Currently, `spacy` is still part of the NLUOutcomeDeterminer, but it is only used to extract entities. Something is still needed to extract intents.
- When the new outcome determiner is added, the docker will need be updated as well as the conversation simulation modules.